### PR TITLE
Feature/continue after

### DIFF
--- a/lib/Dancer2/Plugin/HTTP/ConditionalRequest.pm
+++ b/lib/Dancer2/Plugin/HTTP/ConditionalRequest.pm
@@ -43,11 +43,10 @@ to prevent lost-updates with unsafe-methods in a stateless api (like REST).
             etag            => '2d5730a4c92b1061',
             last_modified   => "Tue, 15 Nov 1994 12:45:26 GMT", # HTTP Date
             required        => false,
-        } => sub {
-            ...
-            # do the real stuff, like updating
-            ...
         }
+        
+        # do the real stuff, like updating or serializing
+        
     };
 
 =head1 RFC_7232 HTTP: Conditional Requests... explained
@@ -132,8 +131,10 @@ those topics.
 
 =head2 http_conditional
 
-This keyword takes as last argument the CODEREF of the part that should be ran
-if the pre-conditions are met.
+This keyword used will check with the passed in parameters to do a conditional
+request. If these pre-conditions are not met execution will be halted with the
+relevant status code. If the preconditions apply, execution will continue on the
+following line.
 
 A optional hashref takes the options
 
@@ -157,13 +158,13 @@ object using C<format_datetime> from L<DateTime::Format::HTTP|DateTime::Format::
 
 =item required
 
-if set to true, it enforces clients that request a unsafe method to privide one
+if set to true, it enforces clients that request a unsafe method to provide one
 or both validators.
 
 =back
 
 If used with either a GET or a HEAD method, the validators mentioned in the
-options are returned in the appropriate HTTP Header Fields.
+options are set and returned in the appropriate HTTP Header Fields.
 
 =cut
 
@@ -519,7 +520,7 @@ L<http://search.cpan.org/dist/Dancer2-Plugin-HTTP-ConditionalRequest/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2015 Theo van Hoesel.
+Copyright 2015-2016 Theo van Hoesel.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of the the Artistic License (2.0). You may obtain a

--- a/lib/Dancer2/Plugin/HTTP/ConditionalRequest.pm
+++ b/lib/Dancer2/Plugin/HTTP/ConditionalRequest.pm
@@ -10,7 +10,7 @@ Version 0.01
 
 =cut
 
-our $VERSION = '0.03';
+our $VERSION = '0.04';
 
 use warnings;
 use strict;
@@ -462,11 +462,6 @@ sub _http_status_server_error_bad_last_modified {
     $_[0]->status(500); # Precondition Failed
     return "http_conditional: bad formatted date 'last_modified'";
 }
-
-# on_plugin_import {
-#     my $dsl = shift;
-#     my $app = $self->app;
-# };
 
 register_plugin;
 


### PR DESCRIPTION
you were not supposed to execute any code after the conditional_request, originally, one would run the code in the code ref - or if not, status codes would be set and nothing else to do.

with this merge, only the status codes are set (amongst other) if the preconditions are not met.

Now, if the conditions are met we continue on the next line

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thema-media/dancer2-plugin-http-conditionalrequest/5)
<!-- Reviewable:end -->
